### PR TITLE
Will a Windows build agent support .NET Framework?

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,19 +1,19 @@
-name: .NET Core
+name: .NET CLI
 
 on: [pull_request]
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+    - name: Setup .NET CLI
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.0.100
-    - name: Compile source (release configuration)
-      run: dotnet build --configuration Release
-    - name: Run unit tests (release configuration)
-      run: dotnet test --configuration Release
+    - name: Compile source
+      run: dotnet build
+    - name: Run unit tests
+      run: dotnet test


### PR DESCRIPTION
Addresses issue #9. 
Build agent was a Unix box, so the .NET Framework projects wouldn't compile or run.
It looks like you can get .NET Framework projects compiling on Unix using [Reference Assemblies](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies.net461/) but that doesn't help with running the example project tests.