### PR TITLE
Addding an external dependency to mapping examples

### DIFF
--- a/example/autofac/Example.cs
+++ b/example/autofac/Example.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Security.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Autofac;
 using ExplicitMapper;
@@ -18,6 +19,9 @@ namespace Example.Autofac
             builder.RegisterMappers(Assembly.GetAssembly(typeof(UserRegistrationMapper)))
                    // Register specific generic mappers.
                    .RegisterGeneric(typeof(XmlSerializerMapper<>)).AsSelf();
+
+            // Register other dependencies.
+            builder.RegisterType<SHA1CryptoServiceProvider>().As<HashAlgorithm>().SingleInstance();
 
             var container = builder.Build();
 

--- a/example/castle.windsor/Example.cs
+++ b/example/castle.windsor/Example.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
@@ -20,6 +21,11 @@ namespace Example.Castle.Windsor
             // Register specific generic mappers.
             container.Register(Component.For(typeof(XmlSerializerMapper<>))
                                         .ImplementedBy(typeof(XmlSerializerMapper<>))
+                                        .LifestyleSingleton());
+
+            // Register other dependencies.
+            container.Register(Component.For<HashAlgorithm>()
+                                        .ImplementedBy<SHA1CryptoServiceProvider>()
                                         .LifestyleSingleton());
 
             Assert.IsNotNull(container.Resolve<IMapper<UserRegistrationModel, User>>());

--- a/example/mapping/PasswordMapper.cs
+++ b/example/mapping/PasswordMapper.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using ExplicitMapper;
+
+namespace Example.ExplicitMapper
+{
+    public class PasswordMapper : ClassMapper<UserRegistrationModel, Password>
+    {
+        private readonly HashAlgorithm hashAlgorithm;
+        public PasswordMapper(HashAlgorithm hashAlgorithm)
+        {
+            this.hashAlgoritm = hashAlgorithm;
+        }
+        
+        protected override void Map(UserRegistrationModel source, Password destination)
+        {
+            destination.HashedPassword = this.hashAlgorithm.ComputeHash(
+                                            Encoding.UTF8.GetBytes(source.Password));
+            
+            destination.CreatedDate = DateTime.UtcNow;
+        }
+    }
+}

--- a/example/mapping/PasswordMapper.cs
+++ b/example/mapping/PasswordMapper.cs
@@ -10,7 +10,7 @@ namespace Example.ExplicitMapper
         private readonly HashAlgorithm hashAlgorithm;
         public PasswordMapper(HashAlgorithm hashAlgorithm)
         {
-            this.hashAlgoritm = hashAlgorithm;
+            this.hashAlgorithm = hashAlgorithm;
         }
         
         protected override void Map(UserRegistrationModel source, Password destination)

--- a/example/mapping/UserRegistrationMapper.cs
+++ b/example/mapping/UserRegistrationMapper.cs
@@ -7,13 +7,16 @@ namespace Example.ExplicitMapper
     {
         private IMapper<UserRegistrationModel, Address> addressMapper;
         private IMapper<UserRegistrationModel, DateTime> dateOfBirthMapper;
+        private IMapper<UserRegistrationModel, Password> passwordMapper;
 
         public UserRegistrationMapper(
             IMapper<UserRegistrationModel, Address> addressMapper,
-            IMapper<UserRegistrationModel, DateTime> dateOfBirthMapper)
+            IMapper<UserRegistrationModel, DateTime> dateOfBirthMapper,
+            IMapper<UserRegistrationModel, Password> passwordMapper)
         {
             this.addressMapper = addressMapper;
             this.dateOfBirthMapper = dateOfBirthMapper;
+            this.passwordMapper = passwordMapper;
         }
 
         protected override void Map(UserRegistrationModel source, User destination)
@@ -27,8 +30,11 @@ namespace Example.ExplicitMapper
             // Using a sub-class-mapping.
             destination.Address = this.addressMapper.Map(source);
 
-            // Use a sub-struct-mapping.
+            // Using a sub-struct-mapping.
             destination.DateOfBirth = this.dateOfBirthMapper.Map(source);
+            
+            // Using a sub-mapper that in-turn has dependencies.
+            destination.Password = this.passwordMapper.Map(source);
         }
     }
 }

--- a/example/mapping/models/Password.cs
+++ b/example/mapping/models/Password.cs
@@ -4,7 +4,7 @@ namespace Example.ExplicitMapper
 {
     public class Password
     {
-        public string HashedPassword { get; set; }
+        public byte[] HashedPassword { get; set; }
 
         public DateTime CreatedDate { get; set; }
     }

--- a/example/mapping/models/Password.cs
+++ b/example/mapping/models/Password.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Example.ExplicitMapper
+{
+    public class Password
+    {
+        public string HashedPassword { get; set; }
+
+        public DateTime CreatedDate { get; set; }
+    }
+}

--- a/example/mapping/models/User.cs
+++ b/example/mapping/models/User.cs
@@ -11,5 +11,7 @@ namespace Example.ExplicitMapper
         public Address Address { get; set; }
 
         public DateTime DateOfBirth { get; set; }
+        
+        public Password Password { get; set; }
     }
 }

--- a/example/mapping/models/UserRegistrationModel.cs
+++ b/example/mapping/models/UserRegistrationModel.cs
@@ -19,5 +19,7 @@ namespace Example.ExplicitMapper
         public int MonthOfBirth { get; set; }
 
         public int YearOfBirth { get; set; }
+        
+        public string Password { get; set; }
     }
 }

--- a/example/microsoft.extensions.dependencyinjection/Example.cs
+++ b/example/microsoft.extensions.dependencyinjection/Example.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Security.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Extensions.DependencyInjection;
 using ExplicitMapper;
@@ -19,6 +20,8 @@ namespace Example.Microsoft.Extensions.DependencyInjection
                 serviceCollection.AddMappers(Assembly.GetAssembly(typeof(UserRegistrationMapper)))
                                  // Register specific generic mappers.
                                  .AddSingleton(typeof(XmlSerializerMapper<>), typeof(XmlSerializerMapper<>))
+                                 // Register other dependencies.
+                                 .AddSingleton<HashAlgorithm, SHA1CryptoServiceProvider>()
                                  .BuildServiceProvider();
 
             Assert.IsNotNull(services.GetService<IMapper<UserRegistrationModel, User>>());

--- a/example/structuremap/Example.cs
+++ b/example/structuremap/Example.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Security.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StructureMap;
 using ExplicitMapper;
@@ -12,7 +13,13 @@ namespace Example.StructureMap
         [TestMethod]
         public void Test()
         {
-            var container = new Container(new MapperRegistry(Assembly.GetAssembly(typeof(UserRegistrationMapper))));
+            var container = new Container(_ => 
+            {
+                // Install all mapper classes from an assembly.
+                _.IncludeRegistry(new MapperRegistry(Assembly.GetAssembly(typeof(UserRegistrationMapper))));
+                // Register other dependencies.
+                _.For<HashAlgorithm>().Use<SHA1CryptoServiceProvider>().Singleton();
+            });
 
             Assert.IsNotNull(container.GetInstance<IMapper<UserRegistrationModel, User>>());
         }

--- a/example/unity/Example.cs
+++ b/example/unity/Example.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Security.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Unity;
 using ExplicitMapper;
@@ -17,7 +18,9 @@ namespace Example.Unity
             // Install all mapper classes from an assembly.
             container.RegisterMappers(Assembly.GetAssembly(typeof(UserRegistrationMapper)))
                      // Register specific generic mappers.
-                     .RegisterSingleton(typeof(XmlSerializerMapper<>), typeof(XmlSerializerMapper<>));
+                     .RegisterSingleton(typeof(XmlSerializerMapper<>), typeof(XmlSerializerMapper<>))
+                    // Register other dependencies.
+                    .RegisterSingleton<HashAlgorithm, SHA1CryptoServiceProvider>();
 
             Assert.IsNotNull(container.Resolve<IMapper<UserRegistrationModel, User>>());
         }


### PR DESCRIPTION
Adding a `HashAlgorithm` dependency as an example of incorporating external dependencies into a mapper for issue #1 .